### PR TITLE
chore: add auto-tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,19 @@
+name: Auto tag
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bump version and push tag
+        uses: mathieudutour/github-tag-action@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch


### PR DESCRIPTION
## Summary
- auto-tag new commits on main using mathieudutour/github-tag-action

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a31827b404832aa05bc880fd91ce81