### PR TITLE
Introduce SQLStatement wrapper and ClauseWhere type

### DIFF
--- a/compose_test.go
+++ b/compose_test.go
@@ -14,13 +14,13 @@ func TestInsert(t *testing.T) {
 		LastName  string `db:"last_name"`
 	}
 
-	clause := Insert[User](nil)
+	stmt := Insert[User](nil)
 	expected := "INSERT INTO user (id, first_name, last_name) VALUES (?, ?, ?);"
-	if got := clause.Write(); got != expected {
+	if got := stmt.Write(); got != expected {
 		t.Fatalf("unexpected SQL: %s", got)
 	}
-	if clause.ModelType != reflect.TypeOf(User{}) {
-		t.Fatalf("unexpected model type: %v", clause.ModelType)
+	if stmt.Clauses[0].ModelType != reflect.TypeOf(User{}) {
+		t.Fatalf("unexpected model type: %v", stmt.Clauses[0].ModelType)
 	}
 }
 
@@ -29,9 +29,9 @@ func TestInsertWithTableOpt(t *testing.T) {
 		Name string
 	}
 
-	clause := Insert[Widget](&SqlOpts{TableName: "widgets"})
+	stmt := Insert[Widget](&SqlOpts{TableName: "widgets"})
 	expected := "INSERT INTO widgets (name) VALUES (?);"
-	if got := clause.Write(); got != expected {
+	if got := stmt.Write(); got != expected {
 		t.Fatalf("unexpected SQL with table opt: %s", got)
 	}
 }
@@ -42,9 +42,9 @@ func TestSelect(t *testing.T) {
 		FirstName string
 	}
 
-	clause := Select[User](nil)
+	stmt := Select[User](nil)
 	expected := "SELECT id, first_name FROM user;"
-	if got := clause.Write(); got != expected {
+	if got := stmt.Write(); got != expected {
 		t.Fatalf("unexpected SQL: %s", got)
 	}
 }
@@ -55,9 +55,9 @@ func TestSelectWhere(t *testing.T) {
 		FirstName string `db:"first_name"`
 	}
 
-	clause := Select[User](nil).Where("id=?", 1)
+	stmt := Select[User](nil).Where("id=?", 1)
 	expected := "SELECT id, first_name FROM user WHERE id=?;"
-	if got := clause.Write(); got != expected {
+	if got := stmt.Write(); got != expected {
 		t.Fatalf("unexpected SQL: %s", got)
 	}
 }
@@ -65,9 +65,9 @@ func TestSelectWhere(t *testing.T) {
 func TestDelete(t *testing.T) {
 	type User struct{}
 
-	clause := Delete[User](nil)
+	stmt := Delete[User](nil)
 	expected := "DELETE FROM user;"
-	if got := clause.Write(); got != expected {
+	if got := stmt.Write(); got != expected {
 		t.Fatalf("unexpected SQL: %s", got)
 	}
 }

--- a/exec.go
+++ b/exec.go
@@ -9,41 +9,44 @@ import (
 	"github.com/kisielk/sqlstruct"
 )
 
-// Exec executes the INSERT SqlClause against the provided database using
+// Exec executes the INSERT statement against the provided database using
 // context.Background(). It delegates to ExecContext.
-func Exec(db *sql.DB, clause SqlClause, model any) (sql.Result, error) {
-	return ExecContext(context.Background(), db, clause, model)
+func Exec(db *sql.DB, stmt SQLStatement, model any) (sql.Result, error) {
+	return ExecContext(context.Background(), db, stmt, model)
 }
 
-// ExecContext executes the INSERT SqlClause against the provided database
+// ExecContext executes the INSERT SQLStatement against the provided database
 // using the supplied context. The model's exported fields are mapped to
-// column names in the clause and passed as arguments to the INSERT statement.
+// column names in the first clause and passed as arguments to the INSERT
+// statement.
 //
-// The SqlClause must be built using Insert[T] so that ModelType and
+// The first clause must be built using Insert[T] so that ModelType and
 // ColumnNames match the fields in the model. ExecContext returns an error if
-// the clause is not an INSERT clause.
-func ExecContext(ctx context.Context, db *sql.DB, clause SqlClause, model any) (sql.Result, error) {
-	if clause.Type != ClauseInsert {
+// the first clause is not an INSERT clause.
+func ExecContext(ctx context.Context, db *sql.DB, stmt SQLStatement, model any) (sql.Result, error) {
+	if len(stmt.Clauses) == 0 || stmt.Clauses[0].Type != ClauseInsert {
 		return nil, fmt.Errorf("sqlcompose: Exec requires an INSERT clause")
 	}
+
+	first := stmt.Clauses[0]
 
 	val := reflect.ValueOf(model)
 	for val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
-	if !val.IsValid() || val.Type() != clause.ModelType {
-		return nil, fmt.Errorf("sqlcompose: model type %T does not match clause type %s", model, clause.ModelType)
+	if !val.IsValid() || val.Type() != first.ModelType {
+		return nil, fmt.Errorf("sqlcompose: model type %T does not match clause type %s", model, first.ModelType)
 	}
 
 	var args []any
-	for i := 0; i < clause.ModelType.NumField(); i++ {
-		f := clause.ModelType.Field(i)
+	for i := 0; i < first.ModelType.NumField(); i++ {
+		f := first.ModelType.Field(i)
 		if f.PkgPath != "" || f.Tag.Get(sqlstruct.TagName) == "-" {
 			continue
 		}
 		args = append(args, val.Field(i).Interface())
 	}
 
-	return db.ExecContext(ctx, clause.Write(), args...)
+	return db.ExecContext(ctx, stmt.Write(), args...)
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -15,7 +15,7 @@ func TestExec(t *testing.T) {
 		LastName  string `db:"last_name"`
 	}
 
-	clause := Insert[User](nil)
+	stmt := Insert[User](nil)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -25,11 +25,11 @@ func TestExec(t *testing.T) {
 
 	u := User{1, "Alice", "Smith"}
 
-	mock.ExpectExec(regexp.QuoteMeta(clause.Write())).
+	mock.ExpectExec(regexp.QuoteMeta(stmt.Write())).
 		WithArgs(u.ID, u.FirstName, u.LastName).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if _, err := Exec(db, clause, u); err != nil {
+	if _, err := Exec(db, stmt, u); err != nil {
 		t.Fatalf("Exec returned error: %v", err)
 	}
 
@@ -44,7 +44,7 @@ func TestExecPointer(t *testing.T) {
 		Name string `db:"name"`
 	}
 
-	clause := Insert[User](nil)
+	stmt := Insert[User](nil)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -54,11 +54,11 @@ func TestExecPointer(t *testing.T) {
 
 	u := &User{ID: 5, Name: "Bob"}
 
-	mock.ExpectExec(regexp.QuoteMeta(clause.Write())).
+	mock.ExpectExec(regexp.QuoteMeta(stmt.Write())).
 		WithArgs(u.ID, u.Name).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if _, err := Exec(db, clause, u); err != nil {
+	if _, err := Exec(db, stmt, u); err != nil {
 		t.Fatalf("Exec returned error: %v", err)
 	}
 
@@ -72,7 +72,7 @@ func TestExecContext(t *testing.T) {
 		ID int `db:"id"`
 	}
 
-	clause := Insert[User](nil)
+	stmt := Insert[User](nil)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -82,11 +82,11 @@ func TestExecContext(t *testing.T) {
 
 	u := User{ID: 10}
 
-	mock.ExpectExec(regexp.QuoteMeta(clause.Write())).
+	mock.ExpectExec(regexp.QuoteMeta(stmt.Write())).
 		WithArgs(u.ID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if _, err := ExecContext(context.Background(), db, clause, u); err != nil {
+	if _, err := ExecContext(context.Background(), db, stmt, u); err != nil {
 		t.Fatalf("ExecContext returned error: %v", err)
 	}
 
@@ -97,7 +97,7 @@ func TestExecContext(t *testing.T) {
 
 func TestExecNonInsert(t *testing.T) {
 	type User struct{ ID int }
-	clause := Select[User](nil)
+	stmt := Select[User](nil)
 
 	db, _, err := sqlmock.New()
 	if err != nil {
@@ -105,7 +105,7 @@ func TestExecNonInsert(t *testing.T) {
 	}
 	defer db.Close()
 
-	if _, err := Exec(db, clause, User{ID: 1}); err == nil {
+	if _, err := Exec(db, stmt, User{ID: 1}); err == nil {
 		t.Fatalf("expected error for non-insert clause")
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kisielk/sqlstruct v0.0.0-20210630145711-dae28ed37023 h1:/pb3UJ+3ZtSEUKWnufwsoVF7f0AX5ytPULbTwHMgbq4=
 github.com/kisielk/sqlstruct v0.0.0-20210630145711-dae28ed37023/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/query_test.go
+++ b/query_test.go
@@ -16,7 +16,7 @@ func TestQuery(t *testing.T) {
 		LastName  string `db:"last_name"`
 	}
 
-	clause := Select[User](nil)
+	stmt := Select[User](nil)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -28,9 +28,9 @@ func TestQuery(t *testing.T) {
 		AddRow(1, "Alice", "Smith").
 		AddRow(2, "Bob", "Jones")
 
-	mock.ExpectQuery(clause.Write()).WillReturnRows(rows)
+	mock.ExpectQuery(stmt.Write()).WillReturnRows(rows)
 
-	got, err := QueryContext[User](context.Background(), db, clause)
+	got, err := QueryContext[User](context.Background(), db, stmt)
 	if err != nil {
 		t.Fatalf("Query returned error: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestQueryWhereArgs(t *testing.T) {
 		FirstName string `db:"first_name"`
 	}
 
-	clause := Select[User](nil).Where("id=?", 1)
+	stmt := Select[User](nil).Where("id=?", 1)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -60,9 +60,9 @@ func TestQueryWhereArgs(t *testing.T) {
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "first_name"}).AddRow(1, "Alice")
-	mock.ExpectQuery(regexp.QuoteMeta(clause.Write())).WithArgs(1).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta(stmt.Write())).WithArgs(1).WillReturnRows(rows)
 
-	got, err := QueryContext[User](context.Background(), db, clause)
+	got, err := QueryContext[User](context.Background(), db, stmt)
 	if err != nil {
 		t.Fatalf("Query returned error: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestQueryPointer(t *testing.T) {
 		FirstName string `db:"first_name"`
 	}
 
-	clause := Select[*User](nil)
+	stmt := Select[*User](nil)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -94,9 +94,9 @@ func TestQueryPointer(t *testing.T) {
 		AddRow(1, "Alice").
 		AddRow(2, "Bob")
 
-	mock.ExpectQuery(clause.Write()).WillReturnRows(rows)
+	mock.ExpectQuery(stmt.Write()).WillReturnRows(rows)
 
-	got, err := QueryContext[*User](context.Background(), db, clause)
+	got, err := QueryContext[*User](context.Background(), db, stmt)
 	if err != nil {
 		t.Fatalf("Query returned error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestQueryPointer(t *testing.T) {
 
 func TestQueryNonSelect(t *testing.T) {
 	type User struct{ ID int }
-	clause := Insert[User](nil)
+	stmt := Insert[User](nil)
 
 	db, _, err := sqlmock.New()
 	if err != nil {
@@ -120,7 +120,7 @@ func TestQueryNonSelect(t *testing.T) {
 	}
 	defer db.Close()
 
-	if _, err := QueryContext[User](context.Background(), db, clause); err == nil {
+	if _, err := QueryContext[User](context.Background(), db, stmt); err == nil {
 		t.Fatalf("expected error for non-select clause")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `SQLStatement` wrapper to hold sequences of `SqlClause`s and render combined SQL
- Support new `ClauseWhere` and `ClauseUpdate` types for homogeneous clause handling
- Update query and exec helpers to operate on `SQLStatement`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a3170168bc832a8e91687b038bafc1