### PR TITLE
Add field filtering option for SELECT statements

### DIFF
--- a/compose_test.go
+++ b/compose_test.go
@@ -49,6 +49,20 @@ func TestSelect(t *testing.T) {
 	}
 }
 
+func TestSelectWithFieldsOpt(t *testing.T) {
+	type User struct {
+		ID        int `db:"id"`
+		FirstName string
+		LastName  string `db:"last_name"`
+	}
+
+	stmt := Select[User](&SqlOpts{Fields: []string{"id", "last_name"}})
+	expected := "SELECT id, last_name FROM user;"
+	if got := stmt.Write(); got != expected {
+		t.Fatalf("unexpected SQL with fields opt: %s", got)
+	}
+}
+
 func TestSelectWhere(t *testing.T) {
 	type User struct {
 		ID        int    `db:"id"`


### PR DESCRIPTION
## Summary
- add `Fields` option to `SqlOpts`
- allow `Select` to filter returned columns based on specified fields
- cover field filter option in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a331e828e0832aba5eb2fb0bb8489f