### PR TITLE
Add Limit, OrderBy, Asc, and Desc clauses

### DIFF
--- a/clause.go
+++ b/clause.go
@@ -10,11 +10,15 @@ import (
 type ClauseType string
 
 const (
-	ClauseInsert ClauseType = "INSERT"
-	ClauseSelect ClauseType = "SELECT"
-	ClauseUpdate ClauseType = "UPDATE"
-	ClauseDelete ClauseType = "DELETE"
-	ClauseWhere  ClauseType = "WHERE"
+	ClauseInsert  ClauseType = "INSERT"
+	ClauseSelect  ClauseType = "SELECT"
+	ClauseUpdate  ClauseType = "UPDATE"
+	ClauseDelete  ClauseType = "DELETE"
+	ClauseWhere   ClauseType = "WHERE"
+	ClauseOrderBy ClauseType = "ORDER BY"
+	ClauseLimit   ClauseType = "LIMIT"
+	ClauseDesc    ClauseType = "DESC"
+	ClauseAsc     ClauseType = "ASC"
 )
 
 // SqlClause represents a SQL statement before rendering.
@@ -44,6 +48,15 @@ func (c SqlClause) Write() string {
 		return fmt.Sprintf("DELETE FROM %s", c.TableName)
 	case ClauseWhere:
 		return fmt.Sprintf("WHERE %s", c.Expr)
+	case ClauseOrderBy:
+		cols := strings.Join(c.ColumnNames, ", ")
+		return fmt.Sprintf("ORDER BY %s", cols)
+	case ClauseLimit:
+		return "LIMIT ?"
+	case ClauseDesc:
+		return "DESC"
+	case ClauseAsc:
+		return "ASC"
 	default:
 		return ""
 	}

--- a/compose.go
+++ b/compose.go
@@ -44,6 +44,36 @@ func (s SQLStatement) Where(expr string, args ...any) SQLStatement {
 	return s
 }
 
+// OrderBy appends an ORDER BY clause to the statement.
+func (s SQLStatement) OrderBy(columns ...string) SQLStatement {
+	s.Clauses = append(s.Clauses, SqlClause{Type: ClauseOrderBy, ColumnNames: columns})
+	return s
+}
+
+// Limit appends a LIMIT clause to the statement.
+func (s SQLStatement) Limit(n int) SQLStatement {
+	s.Clauses = append(s.Clauses, SqlClause{Type: ClauseLimit, Args: []any{n}})
+	return s
+}
+
+// Desc appends a DESC clause ensuring it follows an ORDER BY clause.
+func (s SQLStatement) Desc() SQLStatement {
+	if len(s.Clauses) == 0 || s.Clauses[len(s.Clauses)-1].Type != ClauseOrderBy {
+		panic("DESC must follow ORDER BY clause")
+	}
+	s.Clauses = append(s.Clauses, SqlClause{Type: ClauseDesc})
+	return s
+}
+
+// Asc appends an ASC clause ensuring it follows an ORDER BY clause.
+func (s SQLStatement) Asc() SQLStatement {
+	if len(s.Clauses) == 0 || s.Clauses[len(s.Clauses)-1].Type != ClauseOrderBy {
+		panic("ASC must follow ORDER BY clause")
+	}
+	s.Clauses = append(s.Clauses, SqlClause{Type: ClauseAsc})
+	return s
+}
+
 func getTableName(def string, opts *SqlOpts) string {
 	tableName := def
 	if opts != nil && opts.TableName != "" {

--- a/compose_test.go
+++ b/compose_test.go
@@ -62,6 +62,69 @@ func TestSelectWhere(t *testing.T) {
 	}
 }
 
+func TestSelectOrderByDesc(t *testing.T) {
+	type User struct {
+		ID        int    `db:"id"`
+		FirstName string `db:"first_name"`
+	}
+
+	stmt := Select[User](nil).OrderBy("id").Desc()
+	expected := "SELECT id, first_name FROM user ORDER BY id DESC;"
+	if got := stmt.Write(); got != expected {
+		t.Fatalf("unexpected SQL: %s", got)
+	}
+}
+
+func TestSelectOrderByAsc(t *testing.T) {
+	type User struct {
+		ID        int    `db:"id"`
+		FirstName string `db:"first_name"`
+	}
+
+	stmt := Select[User](nil).OrderBy("id").Asc()
+	expected := "SELECT id, first_name FROM user ORDER BY id ASC;"
+	if got := stmt.Write(); got != expected {
+		t.Fatalf("unexpected SQL: %s", got)
+	}
+}
+
+func TestDescRequiresOrderBy(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when DESC used without ORDER BY")
+		}
+	}()
+	type User struct{ ID int }
+	Select[User](nil).Desc()
+}
+
+func TestAscRequiresOrderBy(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when ASC used without ORDER BY")
+		}
+	}()
+	type User struct{ ID int }
+	Select[User](nil).Asc()
+}
+
+func TestSelectLimit(t *testing.T) {
+	type User struct {
+		ID        int    `db:"id"`
+		FirstName string `db:"first_name"`
+	}
+
+	stmt := Select[User](nil).Limit(5)
+	expected := "SELECT id, first_name FROM user LIMIT ?;"
+	if got := stmt.Write(); got != expected {
+		t.Fatalf("unexpected SQL: %s", got)
+	}
+	args := stmt.Args()
+	if len(args) != 1 || args[0] != 5 {
+		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	type User struct{}
 


### PR DESCRIPTION
## Summary
- support ORDER BY and LIMIT clauses in query builder
- add chainable `OrderBy`, `Limit`, `Asc`, and `Desc` helpers on `SQLStatement`
- validate `Asc` and `Desc` appear after `OrderBy`
- cover ORDER BY direction behavior with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a331734778832a8ce24ca6f733e600