### PR TITLE
Allow ExecContext to insert multiple models

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -11,42 +11,55 @@ import (
 
 // Exec executes the INSERT statement against the provided database using
 // context.Background(). It delegates to ExecContext.
-func Exec(db *sql.DB, stmt SQLStatement, model any) (sql.Result, error) {
-	return ExecContext(context.Background(), db, stmt, model)
+func Exec(db *sql.DB, stmt SQLStatement, models ...any) (sql.Result, error) {
+	return ExecContext(context.Background(), db, stmt, models...)
 }
 
 // ExecContext executes the INSERT SQLStatement against the provided database
-// using the supplied context. The model's exported fields are mapped to
-// column names in the first clause and passed as arguments to the INSERT
-// statement.
+// using the supplied context. The models' exported fields are mapped to column
+// names in the first clause and passed as arguments to the INSERT statement.
 //
 // The first clause must be built using Insert[T] so that ModelType and
 // ColumnNames match the fields in the model. ExecContext returns an error if
-// the first clause is not an INSERT clause.
-func ExecContext(ctx context.Context, db *sql.DB, stmt SQLStatement, model any) (sql.Result, error) {
+// the first clause is not an INSERT clause. It executes the statement once for
+// each provided model and returns the result of the final execution.
+func ExecContext(ctx context.Context, db *sql.DB, stmt SQLStatement, models ...any) (sql.Result, error) {
 	if len(stmt.Clauses) == 0 || stmt.Clauses[0].Type != ClauseInsert {
 		return nil, fmt.Errorf("sqlcompose: Exec requires an INSERT clause")
 	}
 
+	if len(models) == 0 {
+		return nil, fmt.Errorf("sqlcompose: Exec requires at least one model")
+	}
+
 	first := stmt.Clauses[0]
 
-	val := reflect.ValueOf(model)
-	for val.Kind() == reflect.Pointer {
-		val = val.Elem()
-	}
-
-	if !val.IsValid() || val.Type() != first.ModelType {
-		return nil, fmt.Errorf("sqlcompose: model type %T does not match clause type %s", model, first.ModelType)
-	}
-
-	var args []any
-	for i := 0; i < first.ModelType.NumField(); i++ {
-		f := first.ModelType.Field(i)
-		if f.PkgPath != "" || f.Tag.Get(sqlstruct.TagName) == "-" {
-			continue
+	var res sql.Result
+	for _, model := range models {
+		val := reflect.ValueOf(model)
+		for val.Kind() == reflect.Pointer {
+			val = val.Elem()
 		}
-		args = append(args, val.Field(i).Interface())
+
+		if !val.IsValid() || val.Type() != first.ModelType {
+			return nil, fmt.Errorf("sqlcompose: model type %T does not match clause type %s", model, first.ModelType)
+		}
+
+		args := make([]any, 0, first.ModelType.NumField())
+		for i := 0; i < first.ModelType.NumField(); i++ {
+			f := first.ModelType.Field(i)
+			if f.PkgPath != "" || f.Tag.Get(sqlstruct.TagName) == "-" {
+				continue
+			}
+			args = append(args, val.Field(i).Interface())
+		}
+
+		r, err := db.ExecContext(ctx, stmt.Write(), args...)
+		if err != nil {
+			return r, err
+		}
+		res = r
 	}
 
-	return db.ExecContext(ctx, stmt.Write(), args...)
+	return res, nil
 }


### PR DESCRIPTION
## Summary
- allow `Exec` and `ExecContext` to accept variadic models
- execute the statement for each model and return final result
- add test for inserting multiple models

## Testing
- `gofmt -w exec.go exec_test.go`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a33b09a888832abb65359bad8f0971