### PR TITLE
Add QueryOne helper

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -2,6 +2,7 @@ package sqlcompose
 
 import (
 	"context"
+	"database/sql"
 	"reflect"
 	"testing"
 
@@ -158,5 +159,87 @@ func TestQueryNonSelect(t *testing.T) {
 
 	if _, err := QueryContext[User](context.Background(), db, stmt); err == nil {
 		t.Fatalf("expected error for non-select clause")
+	}
+}
+
+func TestQueryOne(t *testing.T) {
+	type User struct {
+		ID        int    `sql:"id"`
+		FirstName string `sql:"first_name"`
+	}
+
+	stmt := Select[User](nil)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "first_name"}).AddRow(1, "Alice")
+	mock.ExpectQuery(stmt.Write()).WillReturnRows(rows)
+
+	got, err := QueryOneContext[User](context.Background(), db, stmt)
+	if err != nil {
+		t.Fatalf("QueryOne returned error: %v", err)
+	}
+
+	want := User{1, "Alice"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestQueryOneNoRows(t *testing.T) {
+	type User struct {
+		ID int `sql:"id"`
+	}
+
+	stmt := Select[User](nil)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id"})
+	mock.ExpectQuery(stmt.Write()).WillReturnRows(rows)
+
+	if _, err := QueryOneContext[User](context.Background(), db, stmt); err != sql.ErrNoRows {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestQueryOneMultipleRows(t *testing.T) {
+	type User struct {
+		ID int `sql:"id"`
+	}
+
+	stmt := Select[User](nil)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2)
+	mock.ExpectQuery(stmt.Write()).WillReturnRows(rows)
+
+	if _, err := QueryOneContext[User](context.Background(), db, stmt); err == nil {
+		t.Fatalf("expected error for multiple rows")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add QueryOne and QueryOneContext helpers that enforce returning a single row
- return `sql.ErrNoRows` when a query yields no rows
- test QueryOne success case and error cases for zero or multiple rows

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a34d86e738832a80fbba42cc0b066f