### PR TITLE
Return error for invalid clause types

### DIFF
--- a/clause.go
+++ b/clause.go
@@ -35,29 +35,29 @@ type SqlClause struct {
 }
 
 // Write renders an individual SQL clause to a string.
-func (c SqlClause) Write() string {
+func (c SqlClause) Write() (string, error) {
 	switch c.Type {
 	case ClauseInsert:
 		cols := strings.Join(c.ColumnNames, ", ")
 		placeholders := strings.TrimRight(strings.Repeat("?, ", len(c.ColumnNames)), ", ")
-		return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", c.TableName, cols, placeholders)
+		return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", c.TableName, cols, placeholders), nil
 	case ClauseSelect:
 		cols := strings.Join(c.ColumnNames, ", ")
-		return fmt.Sprintf("SELECT %s FROM %s", cols, c.TableName)
+		return fmt.Sprintf("SELECT %s FROM %s", cols, c.TableName), nil
 	case ClauseDelete:
-		return fmt.Sprintf("DELETE FROM %s", c.TableName)
+		return fmt.Sprintf("DELETE FROM %s", c.TableName), nil
 	case ClauseWhere:
-		return fmt.Sprintf("WHERE %s", c.Expr)
+		return fmt.Sprintf("WHERE %s", c.Expr), nil
 	case ClauseOrderBy:
 		cols := strings.Join(c.ColumnNames, ", ")
-		return fmt.Sprintf("ORDER BY %s", cols)
+		return fmt.Sprintf("ORDER BY %s", cols), nil
 	case ClauseLimit:
-		return "LIMIT ?"
+		return "LIMIT ?", nil
 	case ClauseDesc:
-		return "DESC"
+		return "DESC", nil
 	case ClauseAsc:
-		return "ASC"
+		return "ASC", nil
 	default:
-		return ""
+		return "", NewErrInvalidClause(string(c.Type))
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,31 @@
+package sqlcompose
+
+import "fmt"
+
+// ErrInvalidClause is returned when a clause of an unknown type is encountered.
+type ErrInvalidClause struct {
+	Clause string
+}
+
+func (e *ErrInvalidClause) Error() string {
+	return fmt.Sprintf("sqlcompose: clause %q is invalid", e.Clause)
+}
+
+// NewErrInvalidClause constructs a new ErrInvalidClause for the given clause name.
+func NewErrInvalidClause(clause string) error {
+	return &ErrInvalidClause{Clause: clause}
+}
+
+// ErrMisplacedClause is returned when a clause is used in an invalid position.
+type ErrMisplacedClause struct {
+	Clause string
+}
+
+func (e *ErrMisplacedClause) Error() string {
+	return fmt.Sprintf("sqlcompose: clause %q cannot be used in this position", e.Clause)
+}
+
+// NewErrMisplacedClause constructs a new ErrMisplacedClause for the given clause name.
+func NewErrMisplacedClause(clause string) error {
+	return &ErrMisplacedClause{Clause: clause}
+}

--- a/exec.go
+++ b/exec.go
@@ -34,6 +34,11 @@ func ExecContext(ctx context.Context, db *sql.DB, stmt SQLStatement, models ...a
 
 	first := stmt.Clauses[0]
 
+	sqlStmt, err := stmt.Write()
+	if err != nil {
+		return nil, err
+	}
+
 	var res sql.Result
 	for _, model := range models {
 		val := reflect.ValueOf(model)
@@ -54,7 +59,7 @@ func ExecContext(ctx context.Context, db *sql.DB, stmt SQLStatement, models ...a
 			args = append(args, val.Field(i).Interface())
 		}
 
-		r, err := db.ExecContext(ctx, stmt.Write(), args...)
+		r, err := db.ExecContext(ctx, sqlStmt, args...)
 		if err != nil {
 			return r, err
 		}

--- a/query.go
+++ b/query.go
@@ -58,7 +58,12 @@ func QueryContext[T any](ctx context.Context, db *sql.DB, stmt SQLStatement) (*Q
 
 	first := stmt.Clauses[0]
 
-	rows, err := db.QueryContext(ctx, stmt.Write(), stmt.Args()...)
+	sqlStmt, err := stmt.Write()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.QueryContext(ctx, sqlStmt, stmt.Args()...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- add ErrInvalidClause and ErrMisplacedClause errors with constructors
- validate clause ordering and expose ErrMisplacedClause from statement writer
- test error propagation for invalid and misplaced clauses

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4aec441e4832a9e66ef428fe9ce30